### PR TITLE
feat: 검색창 Google 연관검색어 자동완성 기능 추가

### DIFF
--- a/app/api/search-suggest/route.ts
+++ b/app/api/search-suggest/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const q = req.nextUrl.searchParams.get("q") ?? "";
+  if (!q.trim()) {
+    return NextResponse.json({ ok: true, data: [] });
+  }
+
+  try {
+    const url = `https://suggestqueries.google.com/complete/search?client=firefox&hl=ko&q=${encodeURIComponent(q)}`;
+    const res = await fetch(url, {
+      headers: { "User-Agent": "Mozilla/5.0" },
+      next: { revalidate: 30 },
+    });
+
+    if (!res.ok) {
+      return NextResponse.json({ ok: false, data: [] });
+    }
+
+    // Firefox client returns: [query, [suggestion1, suggestion2, ...]]
+    const json = await res.json();
+    const suggestions: string[] = Array.isArray(json[1]) ? json[1].slice(0, 8) : [];
+
+    return NextResponse.json({ ok: true, data: suggestions });
+  } catch {
+    return NextResponse.json({ ok: false, data: [] });
+  }
+}

--- a/app/components/UnifiedSearch.tsx
+++ b/app/components/UnifiedSearch.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
 import type React from "react";
 
 type IconProps = React.SVGProps<SVGSVGElement>;
@@ -64,37 +67,172 @@ function SparkleIcon(props: IconProps) {
 }
 
 export default function UnifiedSearch() {
+  const [query, setQuery] = useState("");
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [open, setOpen] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(-1);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const fetchSuggestions = useCallback(async (q: string) => {
+    if (!q.trim()) {
+      setSuggestions([]);
+      setOpen(false);
+      return;
+    }
+    try {
+      const res = await fetch(`/api/search-suggest?q=${encodeURIComponent(q)}`);
+      const json = await res.json();
+      if (json.ok && json.data.length > 0) {
+        setSuggestions(json.data);
+        setOpen(true);
+      } else {
+        setSuggestions([]);
+        setOpen(false);
+      }
+    } catch {
+      setSuggestions([]);
+      setOpen(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => fetchSuggestions(query), 220);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, fetchSuggestions]);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setActiveIdx(-1);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (!open || suggestions.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIdx((i) => Math.min(i + 1, suggestions.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIdx((i) => Math.max(i - 1, -1));
+    } else if (e.key === "Escape") {
+      setOpen(false);
+      setActiveIdx(-1);
+    } else if (e.key === "Enter" && activeIdx >= 0) {
+      e.preventDefault();
+      selectSuggestion(suggestions[activeIdx]);
+    }
+  }
+
+  function selectSuggestion(text: string) {
+    setQuery(text);
+    setSuggestions([]);
+    setOpen(false);
+    setActiveIdx(-1);
+    const url = `https://www.google.com/search?q=${encodeURIComponent(text)}`;
+    window.open(url, "_self");
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    if (activeIdx >= 0 && suggestions[activeIdx]) {
+      e.preventDefault();
+      selectSuggestion(suggestions[activeIdx]);
+    } else {
+      setOpen(false);
+    }
+  }
+
   return (
-    <form
-      aria-label="통합 검색"
-      action="https://www.google.com/search"
-      method="GET"
-      className="flex w-full max-w-2xl items-center gap-4 rounded-full border border-stone-300/80 bg-stone-50/80 px-5 py-3.5 shadow-[0_25px_45px_-35px_rgba(41,37,36,0.65)] backdrop-blur-sm transition hover:border-stone-400/80 focus-within:border-stone-500/80 dark:border-stone-700/80 dark:bg-stone-900/60 dark:shadow-[0_25px_55px_-40px_rgba(250,250,249,0.35)]"
-    >
-      <SearchIcon className="h-5 w-5 text-stone-500 dark:text-stone-400" />
-      <input
-        type="search"
-        name="q"
-        placeholder="Sinbin에서 검색하거나 URL을 입력하세요"
-        autoComplete="off"
-        className="flex-1 bg-transparent text-base text-stone-800 outline-none placeholder:text-stone-400 dark:text-stone-100 dark:placeholder:text-stone-500"
-      />
-      <div className="flex items-center gap-2">
-        <button
-          type="button"
-          className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-stone-200/60 text-stone-600 transition hover:bg-stone-300/80 dark:bg-stone-800/70 dark:text-stone-300 dark:hover:bg-stone-700"
-          aria-label="음성 검색"
+    <div ref={containerRef} className="relative w-full max-w-2xl">
+      <form
+        aria-label="통합 검색"
+        action="https://www.google.com/search"
+        method="GET"
+        onSubmit={handleSubmit}
+        className={`flex w-full items-center gap-4 px-5 py-3.5 shadow-[0_25px_45px_-35px_rgba(41,37,36,0.65)] backdrop-blur-sm transition border bg-stone-50/80 dark:bg-stone-900/60 dark:shadow-[0_25px_55px_-40px_rgba(250,250,249,0.35)] ${
+          open && suggestions.length > 0
+            ? "rounded-t-3xl border-b-0 border-stone-400/80 dark:border-stone-600/80"
+            : "rounded-full border-stone-300/80 hover:border-stone-400/80 focus-within:border-stone-500/80 dark:border-stone-700/80"
+        }`}
+      >
+        <SearchIcon className="h-5 w-5 shrink-0 text-stone-500 dark:text-stone-400" />
+        <input
+          ref={inputRef}
+          type="search"
+          name="q"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setActiveIdx(-1);
+          }}
+          onFocus={() => {
+            if (suggestions.length > 0) setOpen(true);
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder="Sinbin에서 검색하거나 URL을 입력하세요"
+          autoComplete="off"
+          aria-autocomplete="list"
+          aria-expanded={open}
+          aria-controls="search-suggestions"
+          className="flex-1 bg-transparent text-base text-stone-800 outline-none placeholder:text-stone-400 dark:text-stone-100 dark:placeholder:text-stone-500"
+        />
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-stone-200/60 text-stone-600 transition hover:bg-stone-300/80 dark:bg-stone-800/70 dark:text-stone-300 dark:hover:bg-stone-700"
+            aria-label="음성 검색"
+          >
+            <MicIcon className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-stone-300/70 text-stone-500 transition hover:border-stone-400 hover:text-stone-600 dark:border-stone-700 dark:text-stone-400 dark:hover:border-stone-600 dark:hover:text-stone-200"
+            aria-label="작업 탐색"
+          >
+            <SparkleIcon className="h-4 w-4" />
+          </button>
+        </div>
+      </form>
+
+      {open && suggestions.length > 0 && (
+        <ul
+          id="search-suggestions"
+          role="listbox"
+          className="absolute left-0 right-0 z-50 overflow-hidden rounded-b-3xl border border-t-0 border-stone-400/80 bg-stone-50/95 pb-2 shadow-[0_20px_40px_-15px_rgba(41,37,36,0.5)] backdrop-blur-sm dark:border-stone-600/80 dark:bg-stone-900/95 dark:shadow-[0_20px_50px_-20px_rgba(250,250,249,0.25)]"
         >
-          <MicIcon className="h-4 w-4" />
-        </button>
-        <button
-          type="button"
-          className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-stone-300/70 text-stone-500 transition hover:border-stone-400 hover:text-stone-600 dark:border-stone-700 dark:text-stone-400 dark:hover:border-stone-600 dark:hover:text-stone-200"
-          aria-label="작업 탐색"
-        >
-          <SparkleIcon className="h-4 w-4" />
-        </button>
-      </div>
-    </form>
+          <li className="mx-5 mb-1 border-b border-stone-200/60 dark:border-stone-700/60" />
+          {suggestions.map((s, i) => (
+            <li key={s} role="option" aria-selected={i === activeIdx}>
+              <button
+                type="button"
+                onMouseEnter={() => setActiveIdx(i)}
+                onMouseLeave={() => setActiveIdx(-1)}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  selectSuggestion(s);
+                }}
+                className={`flex w-full items-center gap-3.5 px-5 py-2.5 text-left text-sm transition-colors ${
+                  i === activeIdx
+                    ? "bg-stone-100/80 dark:bg-stone-800/60"
+                    : "hover:bg-stone-100/60 dark:hover:bg-stone-800/40"
+                }`}
+              >
+                <SearchIcon className="h-4 w-4 shrink-0 text-stone-400 dark:text-stone-500" />
+                <span className="text-stone-700 dark:text-stone-200">{s}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 }

--- a/app/components/UnifiedSearch.tsx
+++ b/app/components/UnifiedSearch.tsx
@@ -1,0 +1,100 @@
+import type React from "react";
+
+type IconProps = React.SVGProps<SVGSVGElement>;
+
+function SearchIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>
+      <path
+        d="m21 21-3.8-3.8m1.3-5.2a6.5 6.5 0 1 1-13 0 6.5 6.5 0 0 1 13 0Z"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+      />
+    </svg>
+  );
+}
+
+function MicIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>
+      <path
+        d="M12 3a2.5 2.5 0 0 1 2.5 2.5v5a2.5 2.5 0 1 1-5 0v-5A2.5 2.5 0 0 1 12 3Z"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+      />
+      <path
+        d="M19 10.5A7 7 0 0 1 12 17a7 7 0 0 1-7-6.5M12 17v4m0 0h4m-4 0H8"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+      />
+    </svg>
+  );
+}
+
+function SparkleIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>
+      <path
+        d="m12 3 1.1 3.7a1.5 1.5 0 0 0 1 1l3.7 1.1-3.7 1.1a1.5 1.5 0 0 0-1 1L12 15l-1.1-3.7a1.5 1.5 0 0 0-1-1L6.2 8.7l3.7-1.1a1.5 1.5 0 0 0 1-1Z"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+      />
+      <path
+        d="m19 16 0.8 2.6a1 1 0 0 0 0.7 0.7L23 20l-2.5 1a1 1 0 0 0-0.7 0.7L19 24l-0.8-2.6a1 1 0 0 0-0.7-0.7L15 20l2.5-0.7a1 1 0 0 0 0.7-0.7Z"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+      />
+    </svg>
+  );
+}
+
+export default function UnifiedSearch() {
+  return (
+    <form
+      aria-label="통합 검색"
+      action="https://www.google.com/search"
+      method="GET"
+      className="flex w-full max-w-2xl items-center gap-4 rounded-full border border-stone-300/80 bg-stone-50/80 px-5 py-3.5 shadow-[0_25px_45px_-35px_rgba(41,37,36,0.65)] backdrop-blur-sm transition hover:border-stone-400/80 focus-within:border-stone-500/80 dark:border-stone-700/80 dark:bg-stone-900/60 dark:shadow-[0_25px_55px_-40px_rgba(250,250,249,0.35)]"
+    >
+      <SearchIcon className="h-5 w-5 text-stone-500 dark:text-stone-400" />
+      <input
+        type="search"
+        name="q"
+        placeholder="Sinbin에서 검색하거나 URL을 입력하세요"
+        autoComplete="off"
+        className="flex-1 bg-transparent text-base text-stone-800 outline-none placeholder:text-stone-400 dark:text-stone-100 dark:placeholder:text-stone-500"
+      />
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-stone-200/60 text-stone-600 transition hover:bg-stone-300/80 dark:bg-stone-800/70 dark:text-stone-300 dark:hover:bg-stone-700"
+          aria-label="음성 검색"
+        >
+          <MicIcon className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-stone-300/70 text-stone-500 transition hover:border-stone-400 hover:text-stone-600 dark:border-stone-700 dark:text-stone-400 dark:hover:border-stone-600 dark:hover:text-stone-200"
+          aria-label="작업 탐색"
+        >
+          <SparkleIcon className="h-4 w-4" />
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/app/components/UnifiedSearch.tsx
+++ b/app/components/UnifiedSearch.tsx
@@ -20,52 +20,6 @@ function SearchIcon(props: IconProps) {
   );
 }
 
-function MicIcon(props: IconProps) {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>
-      <path
-        d="M12 3a2.5 2.5 0 0 1 2.5 2.5v5a2.5 2.5 0 1 1-5 0v-5A2.5 2.5 0 0 1 12 3Z"
-        fill="none"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={1.5}
-      />
-      <path
-        d="M19 10.5A7 7 0 0 1 12 17a7 7 0 0 1-7-6.5M12 17v4m0 0h4m-4 0H8"
-        fill="none"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={1.5}
-      />
-    </svg>
-  );
-}
-
-function SparkleIcon(props: IconProps) {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>
-      <path
-        d="m12 3 1.1 3.7a1.5 1.5 0 0 0 1 1l3.7 1.1-3.7 1.1a1.5 1.5 0 0 0-1 1L12 15l-1.1-3.7a1.5 1.5 0 0 0-1-1L6.2 8.7l3.7-1.1a1.5 1.5 0 0 0 1-1Z"
-        fill="none"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={1.5}
-      />
-      <path
-        d="m19 16 0.8 2.6a1 1 0 0 0 0.7 0.7L23 20l-2.5 1a1 1 0 0 0-0.7 0.7L19 24l-0.8-2.6a1 1 0 0 0-0.7-0.7L15 20l2.5-0.7a1 1 0 0 0 0.7-0.7Z"
-        fill="none"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={1.5}
-      />
-    </svg>
-  );
-}
-
 export default function UnifiedSearch() {
   const [query, setQuery] = useState("");
   const [suggestions, setSuggestions] = useState<string[]>([]);
@@ -185,22 +139,6 @@ export default function UnifiedSearch() {
           aria-controls="search-suggestions"
           className="flex-1 bg-transparent text-base text-stone-800 outline-none placeholder:text-stone-400 dark:text-stone-100 dark:placeholder:text-stone-500"
         />
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-stone-200/60 text-stone-600 transition hover:bg-stone-300/80 dark:bg-stone-800/70 dark:text-stone-300 dark:hover:bg-stone-700"
-            aria-label="음성 검색"
-          >
-            <MicIcon className="h-4 w-4" />
-          </button>
-          <button
-            type="button"
-            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-stone-300/70 text-stone-500 transition hover:border-stone-400 hover:text-stone-600 dark:border-stone-700 dark:text-stone-400 dark:hover:border-stone-600 dark:hover:text-stone-200"
-            aria-label="작업 탐색"
-          >
-            <SparkleIcon className="h-4 w-4" />
-          </button>
-        </div>
       </form>
 
       {open && suggestions.length > 0 && (

--- a/app/pages/dashboard/DashboardScreen.tsx
+++ b/app/pages/dashboard/DashboardScreen.tsx
@@ -1,5 +1,5 @@
 import QuickLaunch from "@/app/components/QuickLaunch";
-import type React from "react";
+import UnifiedSearch from "@/app/components/UnifiedSearch";
 
 const workspaceCollections = [
   {
@@ -31,69 +31,6 @@ const workspaceSignals = [
   },
 ];
 
-type IconProps = React.SVGProps<SVGSVGElement>;
-
-function SearchIcon(props: IconProps) {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>
-      <path
-        d="m21 21-3.8-3.8m1.3-5.2a6.5 6.5 0 1 1-13 0 6.5 6.5 0 0 1 13 0Z"
-        fill="none"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={1.5}
-      />
-    </svg>
-  );
-}
-
-function MicIcon(props: IconProps) {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>
-      <path
-        d="M12 3a2.5 2.5 0 0 1 2.5 2.5v5a2.5 2.5 0 1 1-5 0v-5A2.5 2.5 0 0 1 12 3Z"
-        fill="none"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={1.5}
-      />
-      <path
-        d="M19 10.5A7 7 0 0 1 12 17a7 7 0 0 1-7-6.5M12 17v4m0 0h4m-4 0H8"
-        fill="none"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={1.5}
-      />
-    </svg>
-  );
-}
-
-function SparkleIcon(props: IconProps) {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden="true" {...props}>
-      <path
-        d="m12 3 1.1 3.7a1.5 1.5 0 0 0 1 1l3.7 1.1-3.7 1.1a1.5 1.5 0 0 0-1 1L12 15l-1.1-3.7a1.5 1.5 0 0 0-1-1L6.2 8.7l3.7-1.1a1.5 1.5 0 0 0 1-1Z"
-        fill="none"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={1.5}
-      />
-      <path
-        d="m19 16 0.8 2.6a1 1 0 0 0 0.7 0.7L23 20l-2.5 1a1 1 0 0 0-0.7 0.7L19 24l-0.8-2.6a1 1 0 0 0-0.7-0.7L15 20l2.5-0.7a1 1 0 0 0 0.7-0.7Z"
-        fill="none"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={1.5}
-      />
-    </svg>
-  );
-}
-
 export default function DashboardScreen() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-stone-100 via-stone-200 to-stone-100 text-stone-900 transition-colors dark:from-stone-950 dark:via-stone-900 dark:to-stone-950 dark:text-stone-100">
@@ -111,37 +48,7 @@ export default function DashboardScreen() {
             </p>
           </div>
 
-          <form
-            aria-label="통합 검색"
-            action="https://www.google.com/search"
-            method="GET"
-            className="flex w-full max-w-2xl items-center gap-4 rounded-full border border-stone-300/80 bg-stone-50/80 px-5 py-3.5 shadow-[0_25px_45px_-35px_rgba(41,37,36,0.65)] backdrop-blur-sm transition hover:border-stone-400/80 focus-within:border-stone-500/80 dark:border-stone-700/80 dark:bg-stone-900/60 dark:shadow-[0_25px_55px_-40px_rgba(250,250,249,0.35)]"
-          >
-            <SearchIcon className="h-5 w-5 text-stone-500 dark:text-stone-400" />
-            <input
-              type="search"
-              name="q"
-              placeholder="Sinbin에서 검색하거나 URL을 입력하세요"
-              autoComplete="off"
-              className="flex-1 bg-transparent text-base text-stone-800 outline-none placeholder:text-stone-400 dark:text-stone-100 dark:placeholder:text-stone-500"
-            />
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-stone-200/60 text-stone-600 transition hover:bg-stone-300/80 dark:bg-stone-800/70 dark:text-stone-300 dark:hover:bg-stone-700"
-                aria-label="음성 검색"
-              >
-                <MicIcon className="h-4 w-4" />
-              </button>
-              <button
-                type="button"
-                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-stone-300/70 text-stone-500 transition hover:border-stone-400 hover:text-stone-600 dark:border-stone-700 dark:text-stone-400 dark:hover:border-stone-600 dark:hover:text-stone-200"
-                aria-label="작업 탐색"
-              >
-                <SparkleIcon className="h-4 w-4" />
-              </button>
-            </div>
-          </form>
+          <UnifiedSearch />
 
           <QuickLaunch />
         </section>


### PR DESCRIPTION
## Summary

- `UnifiedSearch` 컴포넌트에 Google 연관검색어 자동완성 드롭다운 추가
- `/api/search-suggest` Next.js API 라우트 신규 추가 (Google Suggest CORS 우회 프록시)
- 220ms 디바운스로 타이핑 중 불필요한 API 호출 최소화
- 키보드 내비게이션(↑↓ 이동, Enter 선택, Esc 닫기) 및 외부 클릭 닫기 지원
- `aria-autocomplete`, `role="listbox/option"`, `aria-expanded` 등 접근성 속성 적용

## Why

기존 `UnifiedSearch`는 단순 `<form>` 정적 컴포넌트로, 사용자가 검색어를 입력할 때 아무런 피드백이 없었음. Google 새 탭 수준의 UX를 제공하기 위해 연관검색어 자동완성 기능이 필요했음.

## What changed

- **`app/components/UnifiedSearch.tsx`**
  - `"use client"` 전환, `useState` / `useEffect` / `useRef` / `useCallback` 도입
  - 드롭다운 열릴 때 검색창 모서리 `rounded-full` → `rounded-t-3xl` 로 동적 전환 (시각적 연결감)
  - `handleKeyDown` / `selectSuggestion` / `handleSubmit` 핸들러 추가

- **`app/api/search-suggest/route.ts`** (신규)
  - `GET /api/search-suggest?q=...` — `suggestqueries.google.com` 서버사이드 프록시
  - 응답: `{ ok: boolean; data: string[] }` 공통 래핑 스키마 준수
  - `next: { revalidate: 30 }` 캐싱으로 동일 쿼리 중복 요청 방지

## How to test

```bash
npm run dev
```

1. 대시보드(`/`) 진입 후 검색창 클릭
2. 한글 또는 영문 검색어 입력 → 약 220ms 후 연관검색어 드롭다운 표시 확인
3. `↓` / `↑` 키로 항목 이동 → `Enter` 로 Google 검색 이동 확인
4. `Esc` 키 → 드롭다운 닫힘 확인
5. 검색창 외부 클릭 → 드롭다운 자동 닫힘 확인
6. 검색어 전부 삭제 → 드롭다운 사라짐 확인

## Risk & Notes

- Google Suggest API(`suggestqueries.google.com`) 스펙 변경 시 `json[1]` 파싱 로직 영향받을 수 있음 — 롤백 포인트: `app/api/search-suggest/route.ts`
- 별도 환경변수 추가 없음
- 서버사이드 프록시이므로 브라우저에서 외부 도메인으로 직접 요청하지 않음 (CORS 안전)

Related to #7